### PR TITLE
Fix warning error

### DIFF
--- a/fr/functions.sh
+++ b/fr/functions.sh
@@ -57,7 +57,7 @@ pg_aq_france_index() {
     
     # Return speech
     echo -n "L'indice de pollution "
-    if [ -z "$pg_aq_france_default_city"]; then
+    if [ -z "$pg_aq_france_default_city" ]; then
         echo -n "à $pg_aq_france_city "
     fi
     echo "est $index"


### PR DESCRIPTION
Message error was displayed when using the plugin:
plugins_enabled/jarvis-air-quality-france/fr/functions.sh: ligne 60 : [: « ] » manquant

This commit will fix the issue.